### PR TITLE
test-dep - new version available! (1.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "test-client-repo",
-  "version": "1.0.0",
-  "description": "Test repository",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/astro-naughty/test-client-repo.git"
-  },
-  "author": "Marcin Rogalski",
-  "bugs": {
-    "url": "https://github.com/astro-naughty/test-client-repo/issues"
-  },
-  "homepage": "https://github.com/astro-naughty/test-client-repo#readme",
-  "dependencies": {
-    "test-dep": "^1.0.0"
-  }
+    "name": "test-client-repo",
+    "version": "1.0.0",
+    "description": "Test repository",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/astro-naughty/test-client-repo.git"
+    },
+    "author": "Marcin Rogalski",
+    "bugs": {
+        "url": "https://github.com/astro-naughty/test-client-repo/issues"
+    },
+    "homepage": "https://github.com/astro-naughty/test-client-repo#readme",
+    "dependencies": {
+        "test-dep": "1.0.1"
+    }
 }


### PR DESCRIPTION
This is an automatic pull request. It is intended to update version of test-dep to the latetst available.